### PR TITLE
work around a safari offscreen canvas bug

### DIFF
--- a/app/vector-tiles.ts
+++ b/app/vector-tiles.ts
@@ -1,9 +1,5 @@
-import { drawTile2, TileRenderOpts } from './tile-drawing';
-import {
-  getTile,
-  renderDistanceTileInWorker,
-  renderTileInWorker,
-} from './worker-stuff';
+import { TileRenderOpts } from './tile-drawing';
+import { renderDistanceTileInWorker, renderTileInWorker } from './worker-stuff';
 import { WorkerChannel } from './WorkerChannel';
 
 export async function drawTile(
@@ -12,16 +8,12 @@ export async function drawTile(
   coords: { x: number; y: number; z: number },
   opts: TileRenderOpts | undefined
 ) {
-  const offscreen = canvas.transferControlToOffscreen();
-  await channel.sendRequest(
-    renderTileInWorker,
-    {
-      canvas: offscreen,
-      coords,
-      opts,
-    },
-    [offscreen]
-  );
+  const bitmap = await channel.sendRequest(renderTileInWorker, {
+    size: canvas.width,
+    coords,
+    opts,
+  });
+  canvas.getContext('bitmaprenderer')!.transferFromImageBitmap(bitmap);
 }
 export async function drawDistanceTile(
   channel: WorkerChannel,
@@ -29,14 +21,10 @@ export async function drawDistanceTile(
   coords: { x: number; y: number; z: number },
   opts: TileRenderOpts | undefined
 ) {
-  const offscreen = canvas.transferControlToOffscreen();
-  await channel.sendRequest(
-    renderDistanceTileInWorker,
-    {
-      canvas: offscreen,
-      coords,
-      opts,
-    },
-    [offscreen]
-  );
+  const bitmap = await channel.sendRequest(renderDistanceTileInWorker, {
+    size: canvas.width,
+    coords,
+    opts,
+  });
+  canvas.getContext('bitmaprenderer')!.transferFromImageBitmap(bitmap);
 }

--- a/app/worker-stuff.ts
+++ b/app/worker-stuff.ts
@@ -13,17 +13,23 @@ export const setWorkerFile =
 export const getTile =
   key<{ x: number; y: number; z: number }, Tile>('getTile');
 export const renderTileInWorker =
-  key<{
-    coords: { x: number; y: number; z: number };
-    canvas: OffscreenCanvas;
-    opts: TileRenderOpts | undefined;
-  }>('renderTileInWorker');
+  key<
+    {
+      coords: { x: number; y: number; z: number };
+      size: number;
+      opts: TileRenderOpts | undefined;
+    },
+    ImageBitmap
+  >('renderTileInWorker');
 
-export const renderDistanceTileInWorker = key<{
-  coords: { x: number; y: number; z: number };
-  canvas: OffscreenCanvas;
-  opts: TileRenderOpts | undefined;
-}>('renderDistanceTileInWorker');
+export const renderDistanceTileInWorker = key<
+  {
+    coords: { x: number; y: number; z: number };
+    size: number;
+    opts: TileRenderOpts | undefined;
+  },
+  ImageBitmap
+>('renderDistanceTileInWorker');
 
 export const lookup =
   key<

--- a/app/worker.ts
+++ b/app/worker.ts
@@ -72,19 +72,21 @@ channel.handle(setWorkerFile, async ({ file: f, type: fileType }) => {
 
 channel.handle(getTile, ({ z, x, y }) => tileIndex?.getTile(z, x, y));
 
-channel.handle(renderTileInWorker, ({ canvas, coords: { z, x, y }, opts }) => {
+channel.handle(renderTileInWorker, ({ size, coords: { z, x, y }, opts }) => {
   const tile = tileIndex?.getTile(z, x, y);
   if (tile) {
-    drawTile2(canvas, tile, z, opts);
+    const offscreen = new OffscreenCanvas(size, size);
+    drawTile2(offscreen, tile, z, opts);
+    return offscreen.transferToImageBitmap();
   }
 });
 
 channel.handle(
   renderDistanceTileInWorker,
-  ({ canvas, coords: { z, x, y }, opts }) => {
-    console.time('drawDistanceTile');
-    drawDistanceTile(canvas, { z, x, y }, featureTree);
-    console.timeEnd('drawDistanceTile');
+  ({ size, coords: { z, x, y }, opts }) => {
+    const offscreen = new OffscreenCanvas(size, size);
+    drawDistanceTile(offscreen, { z, x, y }, featureTree);
+    return offscreen.transferToImageBitmap();
   }
 );
 


### PR DESCRIPTION
When using `canvas.transferControlToOffscreen()`, safari will sometimes not update the placeholder canvas with the offscreen image, and eventually the placeholder canvas will appear blank after the tab has sat in the background for a bit.

A demo of the bug is at https://static.ryanberdeen.com/share/offscreen-canvas-5m7ZOGtJw6JR6V6wtwH2XWVHRbbeqZGwNY3LjptAQ5FmlpHow7n9oQn61MLgFt1CTmrUZ0FqaoZzGzGkxPO4pihoJrIeQ5txp4U9.html