### PR TITLE
MDX component focus

### DIFF
--- a/app/components/pages/DocsPage.tsx
+++ b/app/components/pages/DocsPage.tsx
@@ -2,18 +2,51 @@ import PageTitle from '../PageTitle';
 import StandardPage from '../StandardPage';
 import Mdx from '../../docs.mdx';
 import { MdxOptionsContext } from '../../docs/also-mdx-jsx-runtime/jsx-dev-runtime';
+import { useHistory, useLocation } from 'react-router';
 
-export default function DocsPage(props) {
-  const params = new URLSearchParams(props.location.search);
+export default function DocsPage() {
+  const location = useLocation();
+  const history = useHistory();
+  const params = new URLSearchParams(location.search);
+  const mdxOptions = {
+    focus: new Set(params.getAll('focus')),
+    showUI: params.get('ui') === 'true',
+    showSimpleTags: params.get('showSimpleTags') === 'true',
+  };
+
   return (
     <StandardPage>
       <PageTitle>Docs</PageTitle>
-      <MdxOptionsContext.Provider
-        value={{
-          focus: new Set(params.getAll('focus')),
-          showUI: params.get('ui') === 'true',
-        }}
-      >
+      {mdxOptions.showUI && (
+        <div>
+          <label>
+            <input
+              type="checkbox"
+              name="showSimpleTags"
+              onChange={() => {
+                params.set(
+                  'showSimpleTags',
+                  (!mdxOptions.showSimpleTags).toString()
+                );
+                history.push({ search: params.toString() });
+              }}
+              checked={mdxOptions.showSimpleTags}
+            />{' '}
+            Show simple tags
+          </label>{' '}
+          {mdxOptions.focus.size > 0 && (
+            <button
+              onClick={() => {
+                params.delete('focus');
+                history.push({ search: params.toString() });
+              }}
+            >
+              Clear Focus
+            </button>
+          )}
+        </div>
+      )}
+      <MdxOptionsContext.Provider value={mdxOptions}>
         <Mdx />
       </MdxOptionsContext.Provider>
     </StandardPage>

--- a/app/components/pages/DocsPage.tsx
+++ b/app/components/pages/DocsPage.tsx
@@ -1,12 +1,21 @@
 import PageTitle from '../PageTitle';
 import StandardPage from '../StandardPage';
 import Mdx from '../../docs.mdx';
+import { MdxOptionsContext } from '../../docs/also-mdx-jsx-runtime/jsx-dev-runtime';
 
-export default function DocsPage() {
+export default function DocsPage(props) {
+  const params = new URLSearchParams(props.location.search);
   return (
     <StandardPage>
       <PageTitle>Docs</PageTitle>
-      <Mdx />
+      <MdxOptionsContext.Provider
+        value={{
+          focus: new Set(params.getAll('focus')),
+          showUI: params.get('ui') === 'true',
+        }}
+      >
+        <Mdx />
+      </MdxOptionsContext.Provider>
     </StandardPage>
   );
 }

--- a/app/docs/also-mdx-jsx-runtime/jsx-dev-runtime.tsx
+++ b/app/docs/also-mdx-jsx-runtime/jsx-dev-runtime.tsx
@@ -57,6 +57,10 @@ function MdxComponentWrapper({
     return children;
   }
 
+  if (typeof type === 'string' && !showSimpleTags) {
+    return children;
+  }
+
   const sourceKey = `${source.fileName}:${source.lineNumber}:${source.columnNumber}`;
 
   const focusKeys = [];
@@ -79,7 +83,7 @@ function MdxComponentWrapper({
   }
   return (
     <>
-      {showUI && (typeof type !== 'string' || showSimpleTags) && (
+      {showUI && (
         <div style={{ background: '#eee', padding: '.5em' }}>
           <a href={`vscode://file/${sourceKey}`}>open in vs code</a> focus on:{' '}
           {focusKeys.map((k) => (

--- a/app/docs/also-mdx-jsx-runtime/jsx-dev-runtime.tsx
+++ b/app/docs/also-mdx-jsx-runtime/jsx-dev-runtime.tsx
@@ -4,6 +4,7 @@ import { Fragment } from 'react/jsx-dev-runtime';
 import { jsxDEV as _original } from 'react/jsx-dev-runtime';
 
 import {
+  Component,
   createContext,
   PropsWithChildren,
   ReactElement,
@@ -55,6 +56,33 @@ export function jsxDEV(
       source,
       self
     );
+  }
+}
+
+class MdxComponentErrorBoundary extends Component<
+  PropsWithChildren<unknown>,
+  { hasError: boolean }
+> {
+  constructor(props: PropsWithChildren<unknown>) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError() {
+    // Update state so the next render will show the fallback UI.
+    return { hasError: true };
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div style={{ background: '#f55', color: 'white', padding: '1em' }}>
+          <strong>An error was thrown by a component.</strong>
+        </div>
+      );
+    }
+
+    return this.props.children;
   }
 }
 
@@ -121,7 +149,9 @@ function MdxComponentWrapper({
           ))}
         </div>
       )}
-      <Context.Provider value={source}>{children}</Context.Provider>
+      <Context.Provider value={source}>
+        <MdxComponentErrorBoundary>{children}</MdxComponentErrorBoundary>
+      </Context.Provider>
     </>
   );
 }

--- a/app/docs/also-mdx-jsx-runtime/jsx-dev-runtime.tsx
+++ b/app/docs/also-mdx-jsx-runtime/jsx-dev-runtime.tsx
@@ -104,10 +104,6 @@ function MdxComponentWrapper({
     return children;
   }
 
-  if (typeof type === 'string' && !showSimpleTags) {
-    return children;
-  }
-
   const sourceKey = `${source.fileName}:${source.lineNumber}:${source.columnNumber}`;
 
   const focusKeys = [];
@@ -128,9 +124,10 @@ function MdxComponentWrapper({
   if (focus.size > 0 && !focusKeys.some((k) => focus.has(k))) {
     return null;
   }
+
   return (
     <>
-      {showUI && (
+      {showUI && (typeof type !== 'string' || showSimpleTags) && (
         <div style={{ background: '#eee', padding: '.5em' }}>
           <a href={`vscode://file/${sourceKey}`}>open in vs code</a> focus on:{' '}
           {focusKeys.map((k) => (

--- a/app/docs/also-mdx-jsx-runtime/jsx-dev-runtime.tsx
+++ b/app/docs/also-mdx-jsx-runtime/jsx-dev-runtime.tsx
@@ -1,0 +1,102 @@
+import { Fragment } from 'react/jsx-dev-runtime';
+export { Fragment };
+
+import { createContext, PropsWithChildren, useContext } from 'react';
+import { jsxDEV as original } from 'react/jsx-dev-runtime';
+import { Link } from 'react-router-dom';
+
+export function jsxDEV(
+  type,
+  originalProps,
+  key,
+  isStaticChildren,
+  source,
+  self
+) {
+  if (type === Fragment) {
+    return original(type, originalProps, key, isStaticChildren, source, self);
+  } else {
+    const { mdxFocusKey, ...props } = originalProps ?? {};
+
+    if (typeof type === 'string') {
+      originalProps['data-also-mdx-source'] = JSON.stringify(source);
+    }
+
+    const children = original(type, props, key, isStaticChildren, source, self);
+    return original(
+      MdxComponentWrapper,
+      {
+        children,
+        source,
+        type,
+        mdxFocusKey,
+      },
+      key,
+      false,
+      source,
+      self
+    );
+  }
+}
+
+const Context = createContext();
+
+function MdxComponentWrapper({
+  children,
+  source,
+  type,
+  mdxFocusKey,
+}: PropsWithChildren<{
+  source: { fileName: string; lineNumber: string; columnNumber: string };
+  type: any;
+  mdxFocusKey: string;
+}>) {
+  const { focus, showUI } = useContext(MdxOptionsContext);
+  const existing = useContext(Context);
+  if (existing) {
+    return children;
+  }
+
+  const sourceKey = `${source.fileName}:${source.lineNumber}:${source.columnNumber}`;
+
+  const focusKeys = [];
+
+  if (mdxFocusKey) {
+    focusKeys.push(mdxFocusKey);
+  }
+
+  focusKeys.push(sourceKey);
+
+  if (typeof type === 'function' && type.name) {
+    focusKeys.push(type.name);
+  }
+  if (typeof type === 'string') {
+    focusKeys.push(type);
+  }
+
+  if (focus.size > 0 && !focusKeys.some((k) => focus.has(k))) {
+    return null;
+  }
+  return (
+    <>
+      {showUI && (
+        <div style={{ background: '#eee', padding: '.5em' }}>
+          <a href={`vscode://file/${sourceKey}`}>open in vs code</a> focus on:{' '}
+          {focusKeys.map((k) => (
+            <>
+              <Link key={k} to={`?focus=${encodeURIComponent(k)}&ui=${showUI}`}>
+                {k}
+              </Link>{' '}
+            </>
+          ))}
+        </div>
+      )}
+      <Context.Provider value={source}>{children}</Context.Provider>
+    </>
+  );
+}
+
+export const MdxOptionsContext = createContext<{
+  focus: Set<string>;
+  showUI: boolean;
+}>({ focus: new Set(), showUI: false });

--- a/app/docs/also-mdx-jsx-runtime/jsx-dev-runtime.tsx
+++ b/app/docs/also-mdx-jsx-runtime/jsx-dev-runtime.tsx
@@ -51,7 +51,7 @@ function MdxComponentWrapper({
   type: any;
   mdxFocusKey: string;
 }>) {
-  const { focus, showUI } = useContext(MdxOptionsContext);
+  const { focus, showUI, showSimpleTags } = useContext(MdxOptionsContext);
   const existing = useContext(Context);
   if (existing) {
     return children;
@@ -79,12 +79,19 @@ function MdxComponentWrapper({
   }
   return (
     <>
-      {showUI && (
+      {showUI && (typeof type !== 'string' || showSimpleTags) && (
         <div style={{ background: '#eee', padding: '.5em' }}>
           <a href={`vscode://file/${sourceKey}`}>open in vs code</a> focus on:{' '}
           {focusKeys.map((k) => (
             <>
-              <Link key={k} to={`?focus=${encodeURIComponent(k)}&ui=${showUI}`}>
+              <Link
+                key={k}
+                to={(location) => {
+                  const params = new URLSearchParams(location.search);
+                  params.set('focus', k);
+                  return { search: params.toString() };
+                }}
+              >
                 {k}
               </Link>{' '}
             </>
@@ -99,4 +106,5 @@ function MdxComponentWrapper({
 export const MdxOptionsContext = createContext<{
   focus: Set<string>;
   showUI: boolean;
-}>({ focus: new Set(), showUI: false });
+  showSimpleTags: boolean;
+}>({ focus: new Set(), showUI: false, showSimpleTags: false });

--- a/app/docs/also-mdx-jsx-runtime/jsx-dev-runtime.tsx
+++ b/app/docs/also-mdx-jsx-runtime/jsx-dev-runtime.tsx
@@ -83,7 +83,7 @@ function MdxComponentWrapper({
         <div style={{ background: '#eee', padding: '.5em' }}>
           <a href={`vscode://file/${sourceKey}`}>open in vs code</a> focus on:{' '}
           {focusKeys.map((k) => (
-            <>
+            <Fragment key={k}>
               <Link
                 key={k}
                 to={(location) => {
@@ -94,7 +94,7 @@ function MdxComponentWrapper({
               >
                 {k}
               </Link>{' '}
-            </>
+            </Fragment>
           ))}
         </div>
       )}

--- a/app/docs/also-mdx-jsx-runtime/jsx-dev-runtime.tsx
+++ b/app/docs/also-mdx-jsx-runtime/jsx-dev-runtime.tsx
@@ -1,26 +1,45 @@
+// @ts-expect-error untyped
 import { Fragment } from 'react/jsx-dev-runtime';
-export { Fragment };
+// @ts-expect-error untyped
+import { jsxDEV as _original } from 'react/jsx-dev-runtime';
 
-import { createContext, PropsWithChildren, useContext } from 'react';
-import { jsxDEV as original } from 'react/jsx-dev-runtime';
+import {
+  createContext,
+  PropsWithChildren,
+  ReactElement,
+  useContext,
+} from 'react';
+
 import { Link } from 'react-router-dom';
 
+export { Fragment };
+
+interface Source {
+  fileName: string;
+  lineNumber: string;
+  columnNumber: string;
+}
+
+const original = _original as typeof jsxDEV;
+
+// https://mdxjs.com/packages/mdx/#parameters-8
+// https://github.com/facebook/react/blob/3e09c27b880e1fecdb1eca5db510ecce37ea6be2/packages/react/src/jsx/ReactJSXElementValidator.js#L305
 export function jsxDEV(
-  type,
-  originalProps,
-  key,
-  isStaticChildren,
-  source,
-  self
-) {
+  type: unknown,
+  originalProps: Record<string, unknown>,
+  key: string | undefined,
+  isStaticChildren: boolean,
+  source: Source,
+  self: unknown
+): ReactElement | null {
   if (type === Fragment) {
     return original(type, originalProps, key, isStaticChildren, source, self);
   } else {
     const { mdxFocusKey, ...props } = originalProps ?? {};
 
-    if (typeof type === 'string') {
-      originalProps['data-also-mdx-source'] = JSON.stringify(source);
-    }
+    // if (typeof type === 'string') {
+    //   props['data-also-mdx-source'] = JSON.stringify(source);
+    // }
 
     const children = original(type, props, key, isStaticChildren, source, self);
     return original(
@@ -29,7 +48,7 @@ export function jsxDEV(
         children,
         source,
         type,
-        mdxFocusKey,
+        mdxFocusKey: typeof mdxFocusKey === 'string' ? mdxFocusKey : undefined,
       },
       key,
       false,
@@ -39,7 +58,7 @@ export function jsxDEV(
   }
 }
 
-const Context = createContext();
+const Context = createContext<Source | undefined>(undefined);
 
 function MdxComponentWrapper({
   children,
@@ -47,8 +66,8 @@ function MdxComponentWrapper({
   type,
   mdxFocusKey,
 }: PropsWithChildren<{
-  source: { fileName: string; lineNumber: string; columnNumber: string };
-  type: any;
+  source: Source;
+  type: unknown;
   mdxFocusKey: string;
 }>) {
   const { focus, showUI, showSimpleTags } = useContext(MdxOptionsContext);

--- a/app/docs/also-mdx-jsx-runtime/jsx-runtime.js
+++ b/app/docs/also-mdx-jsx-runtime/jsx-runtime.js
@@ -1,0 +1,1 @@
+module.exports = require('react/jsx-runtime');

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -54,7 +54,7 @@ module.exports = (env) => ({
           {
             loader: '@mdx-js/loader',
             /** @type {import('@mdx-js/loader').Options} */
-            options: {},
+            options: { jsxImportSource: 'also-mdx-jsx-runtime' },
           },
         ],
       },
@@ -62,6 +62,12 @@ module.exports = (env) => ({
   },
   resolve: {
     extensions: ['.ts', '.tsx', '.js'],
+    alias: {
+      'also-mdx-jsx-runtime': path.resolve(
+        __dirname,
+        'app/docs/also-mdx-jsx-runtime'
+      ),
+    },
   },
   resolveLoader: {
     alias: {


### PR DESCRIPTION
adding `?ui=true` to the docs page URL shows a bar above each custom component in the MDX:

<img width="593" alt="image" src="https://github.com/also/everywhere/assets/15624/714e1943-eae1-4332-8395-c971da54f445">

The "open in vs code" link is a `vscode://` link to the line in the file. The other links set the `focus` query parameter.

Every component is wrapped in a wrapper that conditionally renders it if the focus matches. Multiple `focus` can be specified, although the UI only helps choose one.

Focusing can be done based on the name of the function or simple tag name, the position in the source, or an explicit `mdxFocusKey` added to the component in the MDX, since source position could change while editing.

Wrapping every component in a wrapper could cause some weird issues with components that introspect their children, and probably some other issues as well.

This would make more sense as an MDX plugin that emits JS creating the wrapping components at the top level rather than doing it as a replacement for the JSX runtime as I've done here. This was the easiest to debug and I wanted to experiment a bit with the JSX runtime at this level.

As an MDX plugin, this could also take into account generated slugs for headings.

I experimented a bit with allowing focusing on custom elements nested inside simple tags, but this requires looking at the children props to collect their focus keys and got a bit complicated to do without an MDX plugin.